### PR TITLE
[Forked] Use pystorm via Automattic github fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cython
 jinja2
 Fabric39
-pystorm>=3.1.1
+git+https://github.com/Automattic/pystorm.git@v3.1.4
 requests
 ruamel.yaml
 setuptools


### PR DESCRIPTION
Explicitly hard-code the `pystorm` dependency as the version at:

https://github.com/Automattic/pystorm/tree/v3.1.4