### PR TITLE
include "pystorm @" in the Direct URL requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cython
 jinja2
 Fabric39
-git+https://github.com/Automattic/pystorm.git@v3.1.4
+pystorm @ git+https://github.com/Automattic/pystorm.git@v3.1.4
 requests
 ruamel.yaml
 setuptools


### PR DESCRIPTION
...it doesn't build otherwise due to the way `install_requires` works:

https://github.com/Automattic/streamparse/blob/361b8da3c15895dd18a2b8a0b37545eca167b75e/setup.py#L35-L39